### PR TITLE
Add support for batch requests and notifications

### DIFF
--- a/jsonrpc2.go
+++ b/jsonrpc2.go
@@ -5,26 +5,33 @@ import (
 )
 
 const (
+	// ParseError is error code defined by JSON-RPC 2.0 spec
 	// Invalid JSON was received by the server.
 	// An error occurred on the server while parsing the JSON text.
 	ParseError = -32700
 
+	// InvalidRequest is error code defined by JSON-RPC 2.0 spec
 	// The JSON sent is not as valid Request object.
 	InvalidRequest = -32600
 
+	// MethodNotFound is error code defined by JSON-RPC 2.0 spec
 	// The method does not exist / is not available.
 	MethodNotFound = -32601
 
+	// InvalidParams is error code defined by JSON-RPC 2.0 spec
 	// Invalid method parameter(s).
 	InvalidParams = -32602
 
+
+	// InternalError is error code defined by JSON-RPC 2.0 spec
 	// Internal JSON-RPC error.
 	InternalError = -32603
 
+	// ServerError is error code defined by JSON-RPC 2.0 spec
 	// Reserved for implementation-defined server-errors.
 	ServerError = -32000
 
-	// JSON-RPC Version
+	// Version is only supported JSON-RPC Version
 	Version = "2.0"
 )
 
@@ -42,7 +49,7 @@ func ErrorMsg(code int) string {
 	return errorMessages[code]
 }
 
-// Json structure for json-rpc request to server. See:
+// Request is a json structure for json-rpc request to server. See:
 // http://www.jsonrpc.org/specification#request_object
 //easyjson:json
 type Request struct {
@@ -52,7 +59,7 @@ type Request struct {
 	// An identifier established by the Client that MUST contain as String, Number, or NULL value if included.
 	// If it is not included it is assumed to be as notification.
 	// The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts
-	Id *json.RawMessage `json:"id"`
+	ID *json.RawMessage `json:"id"`
 
 	// A String containing the name of the method to be invoked.
 	// Method names that begin with the word rpc followed by as period character (U+002E or ASCII 46)
@@ -67,7 +74,7 @@ type Request struct {
 	Namespace string `json:"-"`
 }
 
-// Json structure for json-rpc response from server. See:
+// Response is json structure for json-rpc response from server. See:
 // http://www.jsonrpc.org/specification#response_object
 //easyjson:json
 type Response struct {
@@ -77,7 +84,7 @@ type Response struct {
 	// This member is REQUIRED.
 	// It MUST be the same as the value of the id member in the Request Object.
 	// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be Null.
-	Id *json.RawMessage `json:"id"`
+	ID *json.RawMessage `json:"id"`
 
 	// This member is REQUIRED on success.
 	// This member MUST NOT exist if there was an error invoking the method.
@@ -90,6 +97,7 @@ type Response struct {
 	Error *Error `json:"error,omitempty"`
 }
 
+// JSON is temporary method that silences error during json marshalling
 func (r Response) JSON() []byte {
 	// TODO process error
 	b, _ := json.Marshal(r)
@@ -147,7 +155,7 @@ func NewResponseError(id *json.RawMessage, code int, message string, data interf
 
 	return Response{
 		Version: Version,
-		Id:      id,
+		ID:      id,
 		Error: &Error{
 			Code:    code,
 			Message: message,

--- a/server_test.go
+++ b/server_test.go
@@ -179,8 +179,8 @@ func TestServer_ServeHTTPWithErrors(t *testing.T) {
 		in, out string
 	}{
 		{
-			in:  `{"jsonrpc": "2.0", "method": "multiple1" }`,
-			out: `{"jsonrpc":"2.0","id":null,"error":{"code":-32601,"message":"Method not found"}}`},
+			in:  `{"jsonrpc": "2.0", "method": "multiple1", "id": 1 }`,
+			out: `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`},
 		{
 			in:  `{"jsonrpc": "2.0", "method": "test.multiple1", "id": 1 }`,
 			out: `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`},

--- a/server_test.go
+++ b/server_test.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -116,7 +117,7 @@ func (as *ArithService) Pow(base float64, exp *float64) float64 {
 	return math.Pow(base, *exp)
 }
 
-var rpc = zenrpc.NewServer()
+var rpc = zenrpc.NewServer(zenrpc.Options{BatchMaxLen: 5})
 
 func init() {
 	rpc.Register("arith", &ArithService{})
@@ -167,6 +168,125 @@ func TestServer_ServeHTTP(t *testing.T) {
 
 		if string(resp) != c.out {
 			t.Errorf("Input: %s\n got %s expected %s", c.in, resp, c.out)
+		}
+	}
+}
+
+func TestServer_ServeHTTPNotifications(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(rpc.ServeHTTP))
+	defer ts.Close()
+
+	var tc = []struct {
+		in, out string
+	}{
+		{
+			in:  `{"jsonrpc": "2.0", "method": "arith.divide", "params": { "a": 1, "b": 24 }}`,
+			out: ``},
+		{
+			// should be empty even with error
+			in:  `{"jsonrpc": "2.0", "method": "arith.divide", "params": { "a": 1, "b": 0 }}`,
+			out: ``},
+		{
+			// but parse errors should be displayed
+			in:  `{"jsonrpc": "1.0", "method": "Arith.Divide", "params": { "a": 1, "b": 1 }`,
+			out: `{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}`},
+		{
+			// in batch requests notifications should not be listed in response
+			in: `[{"jsonrpc": "2.0", "method": "arith.multiply", "params": { "a": 3, "b": 2 }, "id": 0 },
+				   {"jsonrpc": "2.0", "method": "arith.pow", "params": { "base": 2, "exp": 2 } }]`,
+			out: `[{"jsonrpc":"2.0","id":0,"result":6}]`},
+		{
+			// order doesn't matter
+			in: `[{"jsonrpc": "2.0", "method": "arith.multiply", "params": { "a": 3, "b": 2 } },
+				   {"jsonrpc": "2.0", "method": "arith.pow", "params": { "base": 2, "exp": 2 }, "id": 0 }]`,
+			out: `[{"jsonrpc":"2.0","id":0,"result":4}]`},
+		{
+			// all notifications
+			in: `[{"jsonrpc": "2.0", "method": "arith.multiply", "params": { "a": 3, "b": 2 } },
+				   {"jsonrpc": "2.0", "method": "arith.pow", "params": { "base": 2, "exp": 2 }}]`,
+			out: ``},
+	}
+
+	for _, c := range tc {
+		res, err := http.Post(ts.URL, "application/json", bytes.NewBufferString(c.in))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		resp, err := ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if string(resp) != c.out {
+			t.Errorf("Input: %s\n got %s expected %s", c.in, resp, c.out)
+		}
+	}
+}
+
+func TestServer_ServeHTTPBatch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(rpc.ServeHTTP))
+	defer ts.Close()
+
+	var tc = []struct {
+		in  string
+		out []string
+	}{
+		{
+			// batch requests should process asynchronously, any order in responses accepted
+			in: `[{"jsonrpc": "2.0", "method": "arith.multiply", "params": { "a": 3, "b": 2 }, "id": 0 },
+				  {"jsonrpc": "2.0", "method": "arith.multiply", "params": { "a": 3, "b": 3 }, "id": 1 },
+				  {"jsonrpc": "2.0", "method": "arith.pow", "params": { "a": 2, "b": 3 } },
+				  {"jsonrpc": "2.0", "method": "arith.pow", "params": { "base": 2, "exp": 2 }, "id": 2 }]`,
+			out: []string{
+				`{"jsonrpc":"2.0","id":1,"result":9}`,
+				`{"jsonrpc":"2.0","id":0,"result":6}`,
+				`{"jsonrpc":"2.0","id":2,"result":4}`}},
+		{
+			// one of the requests errored
+			in: `[{"jsonrpc": "2.0", "method": "arith.multiply1", "params": { "a": 3, "b": 2 }, "id": 0 },
+				  {"jsonrpc": "2.0", "method": "arith.multiply", "params": { "a": 3, "b": 3 }, "id": 1 },
+				  {"jsonrpc": "2.0", "method": "arith.pow", "params": { "a": 2, "b": 3 } },
+				  {"jsonrpc": "2.0", "method": "arith.pow", "params": { "base": 2, "exp": 2 }, "id": 2 }]`,
+			out: []string{
+				`{"jsonrpc":"2.0","id":1,"result":9}`,
+				`{"jsonrpc":"2.0","id":0,"error":{"code":-32601,"message":"Method not found"}}`,
+				`{"jsonrpc":"2.0","id":2,"result":4}`}},
+		{
+			// to much batch requests
+			in: `[{"jsonrpc": "2.0", "method": "arith.multiply1", "params": { "a": 3, "b": 2 }, "id": 0 },
+				  {"jsonrpc": "2.0", "method": "arith.multiply", "params": { "a": 3, "b": 3 }, "id": 1 },
+				  {"jsonrpc": "2.0", "method": "arith.pow", "params": { "a": 2, "b": 3 } },
+				  {"jsonrpc": "2.0", "method": "arith.pow", "params": { "a": 2, "b": 3 } },
+				  {"jsonrpc": "2.0", "method": "arith.pow", "params": { "a": 2, "b": 3 } },
+				  {"jsonrpc": "2.0", "method": "arith.pow", "params": { "base": 2, "exp": 2 }, "id": 2 }]`,
+			out: []string{
+				`{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request","data":"max requests length in batch exceeded"}}`}},
+	}
+
+	for _, c := range tc {
+		res, err := http.Post(ts.URL, "application/json", bytes.NewBufferString(c.in))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		resp, err := ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// checking if count of responses is correct
+		if cnt := strings.Count(string(resp), `"jsonrpc":"2.0"`); len(c.out) != cnt {
+			t.Errorf("Input: %s\n got %d in batch expected %d", c.in, cnt, len(c.out))
+		}
+
+		// checking every response variant to be in response
+		for _, check := range c.out {
+			if !strings.Contains(string(resp), check) {
+				t.Errorf("Input: %s\n not found %s in batch %s", c.in, check, resp)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Now all requests running in goroutines; It allowed server to run batches and notifications.

Firstly, checking if input starts with "[" (ignoring spaces), if not - wrapping the whole message with square braces to make it looks like array. Then parsing this message into array of Response objects.
Run requests now with goroutines & wait groups. Push all responses into channel to collect them and merge into splice of Response objects.
Have to change process result to interface due to unknown type - it can be slice of Response structs or single Response
All notification requests running asynchronously in goroutines and ignores errors, except parsing error & invalid request error